### PR TITLE
Support 0.18 or higher versions of docutils

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,7 @@ packages =
 
 python_requires = >=3.7
 install_requires =
-    docutils>=0.17.1,<0.18
+    docutils>=0.17.1
 
 [options.extras_require]
 test =


### PR DESCRIPTION
In my project, `docutils v0.19`  are being used.
`install_requires` in `setup.cfg` must be updated to support 0.18 or higher versions of doctuils.